### PR TITLE
IO::Wrap Documentation Fix

### DIFF
--- a/lib/IO/Wrap.pm
+++ b/lib/IO/Wrap.pm
@@ -83,42 +83,56 @@ sub tell {
     return tell($$self);
 }
 
-#------------------------------
 1;
 __END__
 
 
 =head1 NAME
 
-IO::Wrap - wrap raw filehandles in IO::Handle interface
-
+IO::Wrap - Wrap raw filehandles in the IO::Handle interface
 
 =head1 SYNOPSIS
 
-   use IO::Wrap;
-       
-   ### Do stuff with any kind of filehandle (including a bare globref), or 
-   ### any kind of blessed object that responds to a print() message.
-   ###
-   sub do_stuff {
-       my $fh = shift;         
-       
-       ### At this point, we have no idea what the user gave us... 
-       ### a globref? a FileHandle? a scalar filehandle name?
-       
-       $fh = wraphandle($fh);  
-        
-       ### At this point, we know we have an IO::Handle-like object!
-       
-       $fh->print("Hey there!");
-       ...
-   }
-    
+    use strict;
+    use warnings;
+    use IO::Wrap;
+
+    # this is a fairly senseless use case as IO::Handle already does this.
+    my $wrap_fh = IO::Wrap->new(\*STDIN);
+    my $line = $wrap_fh->getline();
+
+    # Do stuff with any kind of filehandle (including a bare globref), or
+    # any kind of blessed object that responds to a print() message.
+
+    # already have a globref? a FileHandle? a scalar filehandle name?
+    $wrap_fh = IO::Wrap->new($some_unknown_thing);
+
+    # At this point, we know we have an IO::Handle-like object! YAY
+    $wrap_fh->print("Hey there!");
+
+You can also do this using a convenience wrapper function
+
+    use strict;
+    use warnings;
+    use IO::Wrap qw(wraphandle);
+
+    # this is a fairly senseless use case as IO::Handle already does this.
+    my $wrap_fh = wraphandle(\*STDIN);
+    my $line = $wrap_fh->getline();
+
+    # Do stuff with any kind of filehandle (including a bare globref), or
+    # any kind of blessed object that responds to a print() message.
+
+    # already have a globref? a FileHandle? a scalar filehandle name?
+    $wrap_fh = wraphandle($some_unknown_thing);
+
+    # At this point, we know we have an IO::Handle-like object! YAY
+    $wrap_fh->print("Hey there!");
 
 =head1 DESCRIPTION
 
-Let's say you want to write some code which does I/O, but you don't 
-want to force the caller to provide you with a FileHandle or IO::Handle
+Let's say you want to write some code which does I/O, but you don't
+want to force the caller to provide you with a L<FileHandle> or L<IO::Handle>
 object.  You want them to be able to say:
 
     do_stuff(\*STDOUT);
@@ -130,99 +144,178 @@ And even:
 
     do_stuff($any_object_with_a_print_method);
 
-Sure, one way to do it is to force the caller to use tiehandle().  
-But that puts the burden on them.  Another way to do it is to 
-use B<IO::Wrap>, which provides you with the following functions:
+Sure, one way to do it is to force the caller to use C<tiehandle()>.
+But that puts the burden on them.  Another way to do it is to
+use B<IO::Wrap>.
 
+Clearly, when wrapping a raw external filehandle (like C<\*STDOUT>),
+I didn't want to close the file descriptor when the wrapper object is
+destroyed; the user might not appreciate that! Hence, there's no
+C<DESTROY> method in this class.
 
-=over 4
-
-=item wraphandle SCALAR
-
-This function will take a single argument, and "wrap" it based on
-what it seems to be...
-
-=over 4
-
-=item *
-
-B<A raw scalar filehandle name,> like C<"STDOUT"> or C<"Class::HANDLE">.
-In this case, the filehandle name is wrapped in an IO::Wrap object, 
-which is returned.
-
-=item *
-
-B<A raw filehandle glob,> like C<\*STDOUT>.
-In this case, the filehandle glob is wrapped in an IO::Wrap object, 
-which is returned.
-
-=item *
-
-B<A blessed FileHandle object.>
-In this case, the FileHandle is wrapped in an IO::Wrap object if and only
-if your FileHandle class does not support the C<read()> method.
-
-=item *
-
-B<Any other kind of blessed object,> which is assumed to be already
-conformant to the IO::Handle interface.
-In this case, you just get back that object.
-
-=back
-
-=back
-
-
-If you get back an IO::Wrap object, it will obey a basic subset of
-the IO:: interface.  That is, the following methods (note: I said
-I<methods>, not named operators) should work on the thing you get back:
-
-    close 
-    getline 
-    getlines 
-    print ARGS...
-    read BUFFER,NBYTES
-    seek POS,WHENCE
-    tell 
-
-
-
-=head1 NOTES
-
-Clearly, when wrapping a raw external filehandle (like \*STDOUT), 
-I didn't want to close the file descriptor when the "wrapper" object is
-destroyed... since the user might not appreciate that!  Hence,
-there's no DESTROY method in this class.
-
-When wrapping a FileHandle object, however, I believe that Perl will 
-invoke the FileHandle::DESTROY when the last reference goes away,
-so in that case, the filehandle is closed if the wrapped FileHandle
+When wrapping a L<FileHandle> object, however, I believe that Perl will
+invoke the C<FileHandle::DESTROY> when the last reference goes away,
+so in that case, the filehandle is closed if the wrapped L<FileHandle>
 really was the last reference to it.
 
+=head1 FUNCTIONS
 
-=head1 WARNINGS
+L<IO::Wrap> makes the following functions available.
+
+=head2 wraphandle
+
+    # wrap a filehandle glob
+    my $fh = wraphandle(\*STDIN);
+    # wrap a raw filehandle glob by name
+    $fh = wraphandle('STDIN');
+    # wrap a handle in an object
+    $fh = wraphandle('Class::HANDLE');
+
+    # wrap a blessed FileHandle object
+    use FileHandle;
+    my $fho = FileHandle->new("/tmp/foo.txt", "r");
+    $fh = wraphandle($fho);
+
+    # wrap any other blessed object that shares IO::Handle's interface
+    $fh = wraphandle($some_object);
+
+This function is simply a wrapper to the L<IO::Wrap/"new"> constructor method.
+
+=head1 METHODS
+
+L<IO::Wrap> implements the following methods.
+
+=head2 close
+
+    $fh->close();
+
+The C<close> method will attempt to close the system file descriptor. For a
+more complete description, read L<perlfunc/close>.
+
+=head2 fileno
+
+    my $int = $fh->fileno();
+
+The C<fileno> method returns the file descriptor for the wrapped filehandle.
+See L<perlfunc/fileno> for more information.
+
+=head2 getline
+
+    my $data = $fh->getline();
+
+The C<getline> method mimics the function by the same name in L<IO::Handle>.
+It's like calling C<< my $data = <$fh>; >> but only in scalar context.
+
+=head2 getlines
+
+    my @data = $fh->getlines();
+
+The C<getlines> method mimics the function by the same name in L<IO::Handle>.
+It's like calling C<< my @data = <$fh>; >> but only in list context. Calling
+this method in scalar context will result in a croak.
+
+=head2 new
+
+    # wrap a filehandle glob
+    my $fh = IO::Wrap->new(\*STDIN);
+    # wrap a raw filehandle glob by name
+    $fh = IO::Wrap->new('STDIN');
+    # wrap a handle in an object
+    $fh = IO::Wrap->new('Class::HANDLE');
+
+    # wrap a blessed FileHandle object
+    use FileHandle;
+    my $fho = FileHandle->new("/tmp/foo.txt", "r");
+    $fh = IO::Wrap->new($fho);
+
+    # wrap any other blessed object that shares IO::Handle's interface
+    $fh = IO::Wrap->new($some_object);
+
+The C<new> constructor method takes in a single argument and decides to wrap
+it or not it based on what it seems to be.
+
+A raw scalar file handle name, like C<"STDOUT"> or C<"Class::HANDLE"> can be
+wrapped, returning an L<IO::Wrap> object instance.
+
+A raw filehandle glob, like C<\*STDOUT> can also be wrapped, returning an
+L<IO::Wrawp> object instance.
+
+A blessed L<FileHandle> object can also be wrapped. This is a special case
+where an L<IO::Wrap> object instance will only be returned in the case that
+your L<FileHandle> object doesn't support the C<read> method.
+
+Also, any other kind of blessed object that conforms to the
+L<IO::Handle> interface can be passed in. In this case, you just get back
+that object.
+
+In other words, we only wrap it into an L<IO::Wrap> object when what you've
+supplied doesn't already conform to the L<IO::Handle> interface.
+
+If you get back an L<IO::Wrap> object, it will obey a basic subset of
+the C<IO::> interface. It will do so with object B<methods>, not B<operators>.
+
+=head3 CAVEATS
 
 This module does not allow you to wrap filehandle names which are given
-as strings that lack the package they were opened in. That is, if a user 
-opens FOO in package Foo, they must pass it to you either as C<\*FOO> 
+as strings that lack the package they were opened in. That is, if a user
+opens FOO in package Foo, they must pass it to you either as C<\*FOO>
 or as C<"Foo::FOO">.  However, C<"STDIN"> and friends will work just fine.
 
+=head2 print
 
-=head1 VERSION
+    $fh->print("Some string");
+    $fh->print("more", " than one", " string");
 
-$Id: Wrap.pm,v 1.2 2005/02/10 21:21:53 dfs Exp $
-    
+The C<print> method will attempt to print a string or list of strings to the
+filehandle. For a more complete description, read
+L<perlfunc/print>.
+
+=head2 read
+
+    my $buffer;
+    # try to read 30 chars into the buffer starting at the
+    # current cursor position.
+    my $num_chars_read = $fh->read($buffer, 30);
+
+The L<read> method attempts to read a number of characters, starting at the
+filehandle's current cursor position. It returns the number of characters
+actually read. See L<perlfunc/read> for more information.
+
+=head2 seek
+
+    use Fcntl qw(:seek); # import the SEEK_CUR, SEEK_SET, SEEK_END constants
+    # seek to the position in bytes
+    $fh->seek(0, SEEK_SET);
+    # seek to the position in bytes from the current position
+    $fh->seek(22, SEEK_CUR);
+    # seek to the EOF plus bytes
+    $fh->seek(0, SEEK_END);
+
+The C<seek> method will attempt to set the cursor to a given position in bytes
+for the wrapped file handle. See L<perlfunc/seek> for more information.
+
+=head2 tell
+
+    my $bytes = $fh->tell();
+
+The C<tell> method will attempt to return the current position of the cursor
+in bytes for the wrapped file handle. See L<perlfunc/tell> for more
+information.
 
 =head1 AUTHOR
-
-=item Primary Maintainer
-
-Dianne Skoll (F<dfs@roaringpenguin.com>).
-
-=item Original Author
 
 Eryq (F<eryq@zeegee.com>).
 President, ZeeGee Software Inc (F<http://www.zeegee.com>).
 
-=cut
+=head1 CONTRIBUTORS
 
+Dianne Skoll (F<dfs@roaringpenguin.com>).
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright (c) 1997 Erik (Eryq) Dorfman, ZeeGee Software, Inc. All rights reserved.
+
+This program is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
Fix spelling mistakes and add documentation for all of the methods/functions supplied. Organize into proper POD `=headN` sections so we can have nice links in metacpan.
