### PR TITLE
Lower prereqs of perl to 5.6 and other modules

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -31,13 +31,3 @@ on 'test' => sub {
     requires 'Test::More' => '0.88'; # already uses done_testing
     requires 'Test::Tester';
 };
-
-on 'develop' => sub {
-    requires 'Dist::Zilla';
-    requires 'Test::CheckManifest' => '1.29';
-    requires 'Test::CPAN::Changes' => '0.4';
-    requires 'Test::Kwalitee'      => '1.22';
-    requires 'Test::Pod';
-    requires 'Test::Pod::Spelling::CommonMistakes' => '1.000';
-    requires 'Test::TrailingSpace';
-};

--- a/cpanfile
+++ b/cpanfile
@@ -5,29 +5,15 @@ on 'runtime' => sub {
     requires 'overload';
     requires 'parent';
     requires 'Carp';
-    requires 'Exporter' => '5.57';
-    requires 'File::Spec';
+    requires 'Exporter';
     requires 'FileHandle';
     requires 'IO::File';
     requires 'IO::Handle';
     requires 'Symbol';
-};
-
-on 'build' => sub {
-    requires 'ExtUtils::MakeMaker';
 };
 
 on 'test' => sub {
-    requires 'strict';
-    requires 'warnings';
-    requires 'ExtUtils::MakeMaker';
-    requires 'File::Basename';
     requires 'File::Spec';
     requires 'File::Temp';
-    requires 'FileHandle';
-    requires 'IO::File';
-    requires 'IO::Handle';
-    requires 'Symbol';
-    requires 'Test::More' => '0.88'; # already uses done_testing
-    requires 'Test::Tester';
+    requires 'Test::More';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 on 'runtime' => sub {
-    requires 'perl' => '5.008';
+    requires 'perl' => '5.006';
     requires 'strict';
     requires 'warnings';
     requires 'overload';

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,6 @@ on 'runtime' => sub {
     requires 'strict';
     requires 'warnings';
     requires 'overload';
-    requires 'parent';
     requires 'Carp';
     requires 'Exporter';
     requires 'FileHandle';

--- a/lib/IO/AtomicFile.pm
+++ b/lib/IO/AtomicFile.pm
@@ -2,7 +2,8 @@ package IO::AtomicFile;
 
 use strict;
 use warnings;
-use parent 'IO::File';
+use IO::File ();
+our @ISA = qw(IO::File);
 
 our $VERSION = '2.114';
 


### PR DESCRIPTION
This dist is primarily used for IO::Scalar, which is pointless on perls newer than perl 5.6.