### PR TITLE
Update the Free Software Foundation address in the COPYING file

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -11,7 +11,8 @@ Perl; see the file README in Perl distribution.
 
 You should have received a copy of the GNU General Public License
 along with Perl; see the file Copying.  If not, write to
-the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+the Free Software Foundation, 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301, USA.
 
 You should have received a copy of the Artistic License
 along with Perl; see the file Artistic.


### PR DESCRIPTION
The correct address is already present in the LICENSE file. The Free Software Foundation has been at the new address on Franklin Street since 2005.